### PR TITLE
Claude/fix filament retraction 01 e gzb rd v37j fx qr6v y pbfpm

### DIFF
--- a/src/Motion_control.cpp
+++ b/src/Motion_control.cpp
@@ -600,11 +600,9 @@ void motor_motion_switch() // 通道状态切换函数，只控制当前在使�
                 pull_state_old = false; // 重置标记
                 is_backing_out = true; // 标记正在回退
                 filament_now_position[num] = filament_pulling_back;
-                if (device_type == BambuBus_AMS_lite)
-                {
-                    MOTOR_CONTROL[num].set_motion(filament_motion_enum::filament_motion_pull, 100);
-                }
-                // Prepare_For_filament_Pull_Back(OUT_filament_meters); // 通过距离控制退料是否完成
+                // Note: Distance-based retraction control is now handled in motor_motion_run()
+                // for both AMS and AMS Lite via Prepare_For_filament_Pull_Back()
+                // This prevents over-retraction that was causing filament to completely unload
                 break;
             case AMS_filament_motion::before_pull_back:
             case AMS_filament_motion::on_use:
@@ -682,9 +680,15 @@ void motor_motion_run(int error)
     if (!error) // 正常模式
     {
         // 根据设备类型执行不同的电机控制逻辑
+        // Bug Fix: Both AMS and AMS Lite now use distance-based retraction control
+        // to prevent over-retraction that pulls filament completely out of the AMS
         if (device_type == BambuBus_AMS_lite)
         {
-            motor_motion_switch(); // 调度电机
+            // AMS Lite: Use same distance control as regular AMS to prevent infinite retraction
+            if (!Prepare_For_filament_Pull_Back(P1X_OUT_filament_meters))
+            {
+                motor_motion_switch(); // 调度电机
+            }
         }
         else if (device_type == BambuBus_AMS)
         {

--- a/src/Motion_control.cpp
+++ b/src/Motion_control.cpp
@@ -600,9 +600,8 @@ void motor_motion_switch() // 通道状态切换函数，只控制当前在使�
                 pull_state_old = false; // 重置标记
                 is_backing_out = true; // 标记正在回退
                 filament_now_position[num] = filament_pulling_back;
-                // Note: Distance-based retraction control is now handled in motor_motion_run()
-                // for both AMS and AMS Lite via Prepare_For_filament_Pull_Back()
-                // This prevents over-retraction that was causing filament to completely unload
+                // Note: Distance-based retraction control only for regular AMS (P/X-series)
+                // AMS Lite (A1/A1 mini) lets the printer control when to stop via BambuBus
                 break;
             case AMS_filament_motion::before_pull_back:
             case AMS_filament_motion::on_use:
@@ -680,18 +679,16 @@ void motor_motion_run(int error)
     if (!error) // 正常模式
     {
         // 根据设备类型执行不同的电机控制逻辑
-        // Bug Fix: Both AMS and AMS Lite now use distance-based retraction control
-        // to prevent over-retraction that pulls filament completely out of the AMS
         if (device_type == BambuBus_AMS_lite)
         {
-            // AMS Lite: Use same distance control as regular AMS to prevent infinite retraction
-            if (!Prepare_For_filament_Pull_Back(P1X_OUT_filament_meters))
-            {
-                motor_motion_switch(); // 调度电机
-            }
+            // AMS Lite (A1/A1 mini): Printer controls retraction, not BMCU
+            // BMCU just responds to printer commands via BambuBus
+            // Do NOT implement distance-based stopping for AMS Lite
+            motor_motion_switch(); // 调度电机
         }
         else if (device_type == BambuBus_AMS)
         {
+            // Regular AMS (P-series/X-series): BMCU controls retraction distance
             if (!Prepare_For_filament_Pull_Back(P1X_OUT_filament_meters)) // 取反(返回true)，则代表不需要优先考虑退料，并继续调度电机。
             {
                 motor_motion_switch(); // 调度电机

--- a/src/config.h
+++ b/src/config.h
@@ -77,8 +77,9 @@
 #define RGB_UPDATE_INTERVAL_MS  3000        ///< RGB update interval for error states
 
 // Filament distances (in millimeters)
-#define P1X_OUT_FILAMENT_MM     200.0f      ///< Internal filament retraction distance
-#define P1X_OUT_FILAMENT_EXT_MM 700.0f      ///< External filament retraction distance
+// Retraction distance for pulling filament out of toolhead only (not full unload)
+#define P1X_OUT_FILAMENT_MM     80.0f       ///< Toolhead clearance retraction distance (reduced from 200mm)
+#define P1X_OUT_FILAMENT_EXT_MM 700.0f      ///< Full unload retraction distance (for complete filament removal)
 
 // Speed filtering constant
 #define SPEED_FILTER_K          100         ///< Speed calculation filter coefficient

--- a/src/config.h
+++ b/src/config.h
@@ -77,9 +77,8 @@
 #define RGB_UPDATE_INTERVAL_MS  3000        ///< RGB update interval for error states
 
 // Filament distances (in millimeters)
-// Retraction distance for pulling filament out of toolhead only (not full unload)
-#define P1X_OUT_FILAMENT_MM     80.0f       ///< Toolhead clearance retraction distance (reduced from 200mm)
-#define P1X_OUT_FILAMENT_EXT_MM 700.0f      ///< Full unload retraction distance (for complete filament removal)
+#define P1X_OUT_FILAMENT_MM     200.0f      ///< Internal filament retraction distance
+#define P1X_OUT_FILAMENT_EXT_MM 700.0f      ///< External filament retraction distance
 
 // Speed filtering constant
 #define SPEED_FILTER_K          100         ///< Speed calculation filter coefficient


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted filament retraction behavior for AMS Lite (A1/A1 mini): the printer now manages retraction stopping rather than the motor controller enforcing distance-based limits.
  * AMS (P/X-series) models retain distance-based retraction control as previously implemented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->