### PR TITLE
Fix A1 Mini retraction bug: Remove premature stop handler

### DIFF
--- a/src/BambuBus.cpp
+++ b/src/BambuBus.cpp
@@ -710,12 +710,11 @@ bool set_motion(unsigned char read_num, unsigned char statu_flags, unsigned char
                 {
                     data_save.filament_use_flag = 0x04;
                 }
-                // Enable explicit retraction stop: when printer sends 07 00 during retraction, stop immediately
-                if (data_save.filament[read_num].motion_set == AMS_filament_motion::need_pull_back)
+                /*if (data_save.filament[read_num].motion_set == AMS_filament_motion::need_pull_back)
                 {
                     data_save.filament[read_num].motion_set = AMS_filament_motion::idle;
                     data_save.filament_use_flag = 0x00;
-                }
+                }*/
             }
             else if ((statu_flags == 0x07) && (fliment_motion_flag == 0x66)) // 07 66 printer ready return back filament
             {
@@ -1271,7 +1270,7 @@ BambuBus_package_type BambuBus_run()
         int data_length = BambuBus_have_data;
         BambuBus_have_data = 0;
         need_debug = false;
-        // Removed delay(1) - unnecessary delay that reduces packet processing rate
+        delay(1);
         stu = get_packge_type(buf_X, data_length); // have_data
         switch (stu)
         {


### PR DESCRIPTION
Root cause identified by comparing with working BMCU370t firmware (commit 5769c48).

The bug was caused by code at BambuBus.cpp:714-718 that incorrectly interprets the printer's "07 00" status check command as a stop signal during retraction. This caused the BMCU to immediately halt the motor, preventing proper filament retraction and resulting in timeout errors.

Changes:
- Comment out premature retraction stop handler (lines 713-717) This code was already commented out in the working BMCU370t version
- Restore delay(1) in BambuBus_run() for proper packet timing (line 1273) The working version includes this delay for stable communication

Testing: Compare behavior with BMCU370t commit 5769c48 which does not exhibit this retraction failure.

Fixes: A1 Mini "failed to retract filament" error after print completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted AMS lite filament retraction handling behavior to improve reliability.
  * Reintroduced a minor processing delay in the data packet handling loop to enhance stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->