### PR TITLE
Fix A1 Mini retraction bug: Three critical fixes from BMCU370t compar…

### DIFF
--- a/src/BambuBus.cpp
+++ b/src/BambuBus.cpp
@@ -152,22 +152,12 @@ void set_filament_motion(int num, AMS_filament_motion motion)
     {
         _filament *filament = &(data_save.filament[num]);
         filament->motion_set = motion;
-        // Set filament use flag based on motion state
-        switch (motion)
+        // Only update filament_use_flag when transitioning to on_use state
+        // The BambuBus command handler (set_motion) manages the flag for other states
+        // This matches the working BMCU370t firmware behavior
+        if (motion == AMS_filament_motion::on_use)
         {
-        case AMS_filament_motion::on_use:
-        case AMS_filament_motion::before_pull_back:
             data_save.filament_use_flag = 0x04;
-            break;
-        case AMS_filament_motion::need_send_out:
-            data_save.filament_use_flag = 0x02;
-            break;
-        case AMS_filament_motion::need_pull_back:
-            data_save.filament_use_flag = 0x00;
-            break;
-        case AMS_filament_motion::idle:
-            data_save.filament_use_flag = 0x00;
-            break;
         }
     }
 }
@@ -369,6 +359,8 @@ void BambuBus_init()
             channel_colors[i][2] = data_save.filament[i].color_B;
             channel_colors[i][3] = data_save.filament[i].color_A;
         }
+        // Preserve BambuBus_now_filament_num when valid data is loaded from flash
+        // This ensures the stop handler can function correctly after a reset during a print
     }
     else
     {
@@ -384,6 +376,9 @@ void BambuBus_init()
         data_save.filament[3].color_R = 0x88;
         data_save.filament[3].color_G = 0x88;
         data_save.filament[3].color_B = 0x88;
+
+        // Only reset channel selection when no valid data is available
+        data_save.BambuBus_now_filament_num = 0xFF;
     }
     for (auto &j : data_save.filament)
     {
@@ -396,7 +391,6 @@ void BambuBus_init()
         j.motion_set = AMS_filament_motion::idle;
         j.meters = 0;
     }
-    data_save.BambuBus_now_filament_num = 0xFF;
 
     BambuBUS_UART_Init();
 }
@@ -727,20 +721,28 @@ bool set_motion(unsigned char read_num, unsigned char statu_flags, unsigned char
         }
         else if ((read_num == 0xFF) && (statu_flags == 0x01))
         {
-            // Bug #1 Fix: Check bounds before accessing filament array
-            // This also rejects 0xFF (no filament selected) and any negative values
+            // AMS Lite stop signal: Set all filaments to idle
+            // Note: The bounds check on BambuBus_now_filament_num was removed because:
+            // 1. The stop signal (0xFF 0x01) should ALWAYS set all filaments to idle
+            // 2. The previous bounds check caused the stop handler to be skipped when
+            //    BambuBus_now_filament_num was 0xFF, resulting in retraction not stopping
+            // 3. The motion check below only reads from the array if we need to verify
+            //    we're not in on_use state, but we can safely check bounds just for that read
             if ((unsigned)data_save.BambuBus_now_filament_num < 4)
             {
                 AMS_filament_motion motion = data_save.filament[data_save.BambuBus_now_filament_num].motion_set;
-                if (motion != AMS_filament_motion::on_use)
+                if (motion == AMS_filament_motion::on_use)
                 {
-                    for (int i = 0; i < 4; i++)
-                    {
-                        data_save.filament[i].motion_set = AMS_filament_motion::idle;
-                    }
-                    data_save.filament_use_flag = 0x00;
+                    // Don't stop if actively in use (printing)
+                    return true;
                 }
             }
+            // Always set all filaments to idle when stop signal received (unless in use)
+            for (int i = 0; i < 4; i++)
+            {
+                data_save.filament[i].motion_set = AMS_filament_motion::idle;
+            }
+            data_save.filament_use_flag = 0x00;
         }
     }
     else if (BambuBus_address == BambuBus_none) // none


### PR DESCRIPTION
…ison

Root cause analysis by comparing with working BMCU370t firmware (commit 5769c48).

## Bug #1: Stop handler skipped due to overzealous bounds check
Location: set_motion() for AMS Lite stop signal (0xFF 0x01)

The previous "Bug #1 Fix" added a bounds check that wrapped the entire stop handler, causing it to be skipped when BambuBus_now_filament_num was 0xFF. This resulted in retraction never stopping and filament being completely unloaded from the AMS.

Fix: Restructured logic so the stop signal ALWAYS sets filaments to idle, with bounds check only protecting the on_use state verification.

## Bug #2: Channel number always reset on init
Location: BambuBus_init()

BambuBus_now_filament_num was unconditionally reset to 0xFF on every init, even when valid data was loaded from flash. This made Bug #1 more likely to trigger.

Fix: Only reset channel number when no valid flash data is available.

## Bug #3: set_filament_motion flag behavior changed
Location: set_filament_motion()

The function was modified to set filament_use_flag for ALL motion states, but the working BMCU370t only sets it when transitioning to on_use.

Fix: Restore original behavior - only set flag for on_use transition.

Testing: Compare behavior with BMCU370t commit 5769c48 which does not exhibit retraction failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filament selection now persists during reset operations, preventing loss of tracking during active prints
  * Added buffer overflow protection to improve system stability in serial communication
  * Refined stop behavior to prevent halting operations when filament is actively in use

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->